### PR TITLE
fix: Enable hot reload on develop

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -14,6 +14,7 @@ const isDevelopment = !isProduction;
 const baseURL = process.env.BASE_URL ?? "/";
 
 const config: WebpackOptionsNormalized = {
+  target: "web",
   mode: isProduction ? "production" : "development",
   entry: {
     index: {


### PR DESCRIPTION
When we change code, it does auto-rebuild but doesn't do auto-refresh on the browser. This PR fixes it.

see: https://github.com/webpack/webpack-dev-server/issues/2758#issuecomment-715629138